### PR TITLE
Fixed crash when spawning item in full inventory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
     repositories {
         mavenCentral()
         maven {
-            name = "forge"
+            name = "ForgeFS"
             url = "http://files.minecraftforge.net/maven"
         }
         maven {

--- a/src/main/java/matteroverdrive/compat/modules/nei/CompatNEI.java
+++ b/src/main/java/matteroverdrive/compat/modules/nei/CompatNEI.java
@@ -30,6 +30,7 @@ import matteroverdrive.init.MatterOverdriveBlocks;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -61,7 +62,7 @@ public class CompatNEI implements INEIGuiHandler
 
 	@Override
 	public Iterable<Integer> getItemSpawnSlots(GuiContainer guiContainer, ItemStack itemStack) {
-		return null;
+		return new ArrayList<Integer>();
 	}
 
 	@Override

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 1,
+    "description": "Resources used for Matter Overdrive"
+  }
+}


### PR DESCRIPTION
You [shouldn't actually return null](https://github.com/Chicken-Bones/NotEnoughItems/blob/1.7/src/codechicken/nei/api/INEIGuiHandler.java#L18). Also fixed Forge repo name in build.gradle and added pack.mcmeta. I didn't tested this yet because I'm still compiling (for about an hour, lol) this version. I'm not sure why build time is so long.