### PR TITLE
Fixed chunk loading bug with anomalies

### DIFF
--- a/src/main/java/matteroverdrive/tile/TileEntityGravitationalAnomaly.java
+++ b/src/main/java/matteroverdrive/tile/TileEntityGravitationalAnomaly.java
@@ -761,11 +761,14 @@ public class TileEntityGravitationalAnomaly extends MOTileEntity implements ISca
         while (iterator.hasNext())
         {
             AnomalySuppressor s = iterator.next();
-            if (!s.isValid())
+            boolean isLoaded = worldObj.getChunkFromBlockCoords(s.getX(), s.getZ()).isChunkLoaded;
+            if (!s.isValid() && isLoaded)
             {
                 iterator.remove();
             }
-            s.tick();
+            if(isLoaded) {
+                s.tick();
+            }
             suppression *= s.getAmount();
         }
         return suppression;


### PR DESCRIPTION
Added logic to suppression calculations to account for unloaded chunks of nearby stabilizers. This should prevent anomalies from eating blocks around the fusion reactor on what should be a stable ingame build.