### PR TITLE
Added config option to disable Android name labels

### DIFF
--- a/src/main/java/matteroverdrive/client/render/entity/EntityRendererRougeAndroid.java
+++ b/src/main/java/matteroverdrive/client/render/entity/EntityRendererRougeAndroid.java
@@ -37,6 +37,7 @@ import org.lwjgl.opengl.GL12;
 public class EntityRendererRougeAndroid extends RenderBiped
 {
     private boolean hologram;
+    public static boolean RENDER_ANDROID_LABEL = true;
     public static final ResourceLocation texture = new ResourceLocation(Reference.PATH_ENTITIES + "android.png");
     public static final ResourceLocation texture_hologram = new ResourceLocation(Reference.PATH_ENTITIES + "android_holo.png");
 
@@ -66,7 +67,7 @@ public class EntityRendererRougeAndroid extends RenderBiped
             return true;
         }else
         {
-            return Minecraft.getMinecraft().thePlayer.getDistanceToEntity(entityLiving) < 18;
+            return RENDER_ANDROID_LABEL && Minecraft.getMinecraft().thePlayer.getDistanceToEntity(entityLiving) < 18;
         }
     }
 

--- a/src/main/java/matteroverdrive/entity/monster/EntityRogueAndroid.java
+++ b/src/main/java/matteroverdrive/entity/monster/EntityRogueAndroid.java
@@ -19,6 +19,7 @@
 package matteroverdrive.entity.monster;
 
 import matteroverdrive.MatterOverdrive;
+import matteroverdrive.client.render.entity.EntityRendererRougeAndroid;
 import matteroverdrive.handler.ConfigurationHandler;
 import matteroverdrive.util.IConfigSubscriber;
 import net.minecraft.entity.EntityLiving;
@@ -96,6 +97,7 @@ public class EntityRogueAndroid implements IConfigSubscriber
 
         EntityRangedRogueAndroidMob.UNLIMITED_WEAPON_ENERGY = config.getBool("unlimited_weapon_energy",ConfigurationHandler.CATEGORY_ENTITIES + ".rogue_android",true,"Do Ranged Rogue Androids have unlimited weapon energy in their weapons");
         MAX_ANDROIDS_PER_CHUNK = config.getInt("max_android_per_chunk",ConfigurationHandler.CATEGORY_ENTITIES + ".rogue_android",4,"The max amount of Rogue Android that can spawn in a given chunk");
+        EntityRendererRougeAndroid.RENDER_ANDROID_LABEL = config.getBool("render_android_label",ConfigurationHandler.CATEGORY_ENTITIES + ".rogue_android",true,"Whether to render the name label above a Rogue Android (without a team)");
     }
 
     private static void loadBiomeBlacklist(ConfigurationHandler config)


### PR DESCRIPTION
The Rogue Android name labels were really bugging me, so I made an option to disable them.

Note that this does not disable name labels for androids in a team.

This is for the 1.7.10 version.