### PR TITLE
Add files to be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ hs_err_pid*
 /.classpath
 /.project
 /bin
+MatterOverdrive1_Client.launch
+MatterOverdrive1_Server.launch
  
 # intellij
 /out


### PR DESCRIPTION
MatterOverdrive1_Client.launch and MatterOverdrive1_Server.launch are now ignored.
This is in response to PR #619 .